### PR TITLE
IComparable

### DIFF
--- a/src/IriTools/IriReference.cs
+++ b/src/IriTools/IriReference.cs
@@ -18,7 +18,7 @@ namespace IriTools;
 /// </summary>
 [Serializable]
 [JsonConverter(typeof(IriReferenceConverter))]
-public class IriReference : IEquatable<IriReference>
+public class IriReference : IEquatable<IriReference>, IComparable<IriReference>
 {
     public Uri uri { get; set; }
 
@@ -28,6 +28,12 @@ public class IriReference : IEquatable<IriReference>
 
     bool IEquatable<IriReference>.Equals(IriReference? other) =>
         other != null && (ReferenceEquals(this, other) || ToString().Equals(other.ToString()));
+
+    public int CompareTo(IriReference? other)
+    {
+        if (other == null) throw new NullReferenceException("Cannot compare to null IriReference");
+        return String.Compare(ToString(), other.ToString(), StringComparison.Ordinal);
+    }
 
     public override bool Equals(object? other) =>
         other != null && (ReferenceEquals(this, other) || (other is IriReference iri && ToString().Equals(iri.ToString())));

--- a/src/IriTools/IriTools.csproj
+++ b/src/IriTools/IriTools.csproj
@@ -12,7 +12,7 @@
         <PackageTags>RDF IRI</PackageTags>
         <PackageId>IriTools</PackageId>
         <Authors>Dag Hovland</Authors>
-        <PackageVersion>2.0.0</PackageVersion>
+        <PackageVersion>2.1.0</PackageVersion>
         <RepositoryUrl>https://github.com/equinor/iri-tools</RepositoryUrl>
         <Description>A library for IRI References, compatible with Rdf.</Description>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/IriToolsNugetTest/IriToolsNugetTest.csproj
+++ b/src/IriToolsNugetTest/IriToolsNugetTest.csproj
@@ -15,7 +15,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
-        <PackageReference Include="IriTools" Version="1.1.0" />
+        <PackageReference Include="IriTools" Version="2.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
         <PackageReference Include="xunit" Version="2.7.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">

--- a/src/IriToolsNugetTest/TestIriReference.cs
+++ b/src/IriToolsNugetTest/TestIriReference.cs
@@ -10,7 +10,23 @@ public class TestIriReference
     {
         var iriRef1 = new IriReference("https://example.com/id#1");
         var iriRef2 = new IriReference("https://example.com/id#2");
-        iriRef1.Should().NotBeEquivalentTo(iriRef2);
+        iriRef1.Should().NotBe(iriRef2);
         iriRef1.uri.Equals(iriRef2.uri).Should().BeTrue();
+    }
+    
+    [Fact]
+    public void Iris__ShouldBeEqual()
+    {
+        var iriRef1 = new IriReference("https://example.com/id");
+        var iriRef2 = new IriReference("https://example.com/id");
+        iriRef1.Should().Be(iriRef2);
+    }
+    
+    [Fact]
+    public void Iris__Should__ImplementIComparable()
+    {
+        IComparable<IriReference> iriRef1 = new IriReference("https://example.com/id");
+        var iriRef2 = new IriReference("https://example.com/id");
+        iriRef1.CompareTo(iriRef2).Should().Be(0);
     }
 }

--- a/src/UnitTests/TestIriReference.cs
+++ b/src/UnitTests/TestIriReference.cs
@@ -11,10 +11,17 @@ public class TestIriReference
     {
         var iriRef1 = new IriReference("https://example.com/id#1");
         var iriRef2 = new IriReference("https://example.com/id#2");
-        iriRef1.Should().NotBeEquivalentTo(iriRef2);
+        iriRef1.Should().NotBe(iriRef2);
         iriRef1.uri.Equals(iriRef2.uri).Should().BeTrue();
     }
 
+    [Fact]
+    public void IriReference__Implements__IComparable()
+    {
+        IComparable<IriReference> iriRef1 = new IriReference("https://example.com/id#1");
+        var iriRef2 = new IriReference("https://example.com/id#2");
+        iriRef1.CompareTo(iriRef2).Should().Be(-1);
+    }
 
     [Fact]
     public void Should_Deserialize_Json_To_IriReference()


### PR DESCRIPTION
Added implementation of the IComparable interface. This is necessary for use f.ex. as key in a FSharp.Collections.Map