### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
     paths:
       - ".*src/IriTools/IriReference.*"
   
+permissions:
+  contents: read
 jobs:
   publish:
     name: "Nuget publish"


### PR DESCRIPTION
[AB#353691](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/353691)

Potential fix for [https://github.com/equinor/iri-tools/security/code-scanning/2](https://github.com/equinor/iri-tools/security/code-scanning/2)

To fix this problem, you should explicitly set the `permissions` block in your workflow file so that the job does not run with unnecessary permissions. Add a `permissions:` key either at the root level under the workflow name (to apply to all jobs), or inside the specific job (`publish:`). In this case, minimal permissions are sufficient: the job needs to read repository contents to check out the code and access secrets, but does not require write permissions for issues, pull requests, or repository contents. Add the following block before the `jobs:` section:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
