### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_pull_request_tester.yml
+++ b/.github/workflows/_pull_request_tester.yml
@@ -1,4 +1,6 @@
 name: "Run tests (required)"
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   merge_group:


### PR DESCRIPTION
[AB#353691](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/353691)

Potential fix for [https://github.com/equinor/iri-tools/security/code-scanning/1](https://github.com/equinor/iri-tools/security/code-scanning/1)

To fix the problem, we should add a `permissions` key to the workflow either at the root or at the job level. For simplicity and given there's only one job, add it at the root level, just below/name or /on. The minimal permission required for this workflow is `contents: read`, as all the steps only need to read code from the repository. No steps require write access (like creating issues or merging PRs), so we should not grant those. No additional imports or code changes are required since this is a workflow YAML file configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
