### PR TITLE
Added segment escape creation method

### DIFF
--- a/src/IriTools/IriReference.cs
+++ b/src/IriTools/IriReference.cs
@@ -25,7 +25,7 @@ public class IriReference : IEquatable<IriReference>, IComparable<IriReference>,
     public static implicit operator IriReference(Uri uri) => new(uri);
     public static implicit operator IriReference(string uri) => new(uri);
     public static implicit operator Uri(IriReference r) => r.uri;
-    
+
     /// <summary>
     /// Escapes the segments as data segments and appends them to the base IRI
     /// </summary>
@@ -34,9 +34,9 @@ public class IriReference : IEquatable<IriReference>, IComparable<IriReference>,
     /// <returns>The escaped combined IRI, f.ex. https://example.com/a%281%29/b/c</returns>
     public static IriReference FromDataSegments(IriReference baseIri, params string[] segments)
     {
-        var escapedSegments = segments.Select(v=> Uri.EscapeDataString(v.Trim())).ToArray();
+        var escapedSegments = segments.Select(v => Uri.EscapeDataString(v.Trim())).ToArray();
         var path = string.Join("/", escapedSegments);
-        return  new Uri(baseIri.uri, path);
+        return new Uri(baseIri.uri, path);
     }
 
     bool IEquatable<IriReference>.Equals(IriReference? other) =>
@@ -58,14 +58,14 @@ public class IriReference : IEquatable<IriReference>, IComparable<IriReference>,
             IriReference iri => string.Compare(ToString(), iri.ToString(), StringComparison.Ordinal),
             _ => throw new ArgumentException("Object is not an IriReference")
         };
-    
-    
+
+
     public override bool Equals(object? other) =>
         other != null && (ReferenceEquals(this, other) || (other is IriReference iri && ToString().Equals(iri.ToString())));
 
     public override string ToString() => uri.ToString();
-    
-    
+
+
 
 
     /// <summary>

--- a/src/IriTools/IriReference.cs
+++ b/src/IriTools/IriReference.cs
@@ -25,6 +25,19 @@ public class IriReference : IEquatable<IriReference>, IComparable<IriReference>,
     public static implicit operator IriReference(Uri uri) => new(uri);
     public static implicit operator IriReference(string uri) => new(uri);
     public static implicit operator Uri(IriReference r) => r.uri;
+    
+    /// <summary>
+    /// Escapes the segments as data segments and appends them to the base IRI
+    /// </summary>
+    /// <param name="baseIri">The base part of the IRI, f.ex. https://example.com/</param>
+    /// <param name="segments">Any number of segments, f.ex. a(1), b and c</param>
+    /// <returns>The escaped combined IRI, f.ex. https://example.com/a%281%29/b/c</returns>
+    public static IriReference FromDataSegments(IriReference baseIri, params string[] segments)
+    {
+        var escapedSegments = segments.Select(v=> Uri.EscapeDataString(v.Trim())).ToArray();
+        var path = string.Join("/", escapedSegments);
+        return  new Uri(baseIri.uri, path);
+    }
 
     bool IEquatable<IriReference>.Equals(IriReference? other) =>
         other != null && (ReferenceEquals(this, other) || ToString().Equals(other.ToString()));
@@ -51,6 +64,7 @@ public class IriReference : IEquatable<IriReference>, IComparable<IriReference>,
         other != null && (ReferenceEquals(this, other) || (other is IriReference iri && ToString().Equals(iri.ToString())));
 
     public override string ToString() => uri.ToString();
+    
     
 
 

--- a/src/IriTools/IriTools.csproj
+++ b/src/IriTools/IriTools.csproj
@@ -12,7 +12,7 @@
         <PackageTags>RDF IRI</PackageTags>
         <PackageId>IriTools</PackageId>
         <Authors>Dag Hovland</Authors>
-        <PackageVersion>2.3.0</PackageVersion>
+        <PackageVersion>2.4.0</PackageVersion>
         <RepositoryUrl>https://github.com/equinor/iri-tools</RepositoryUrl>
         <Description>A library for IRI References, compatible with Rdf.</Description>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/UnitTests/TestIriReference.cs
+++ b/src/UnitTests/TestIriReference.cs
@@ -22,7 +22,7 @@ public class TestIriReference
         var iriRef2 = new IriReference("https://example.com/id#2");
         iriRef1.CompareTo(iriRef2).Should().Be(-1);
     }
-    
+
     [Fact]
     public void IriReference__Implements__IComparableObject()
     {
@@ -30,7 +30,7 @@ public class TestIriReference
         object iriRef2 = new IriReference("https://example.com/id#2");
         iriRef1.CompareTo(iriRef2).Should().Be(-1);
     }
-    
+
     [Fact]
     public void Should_Deserialize_Json_To_IriReference()
     {
@@ -59,16 +59,16 @@ public class TestIriReference
         iriRef.Should().NotBeNull();
         iriRef.Should().Be(expectedIriReference);
     }
-    
+
     [Fact]
     public void Segments__Are__Escaped()
     {
         // Arrange
         var baseIri = new IriReference("https://example.com/");
-        
+
         // Act
         var newIri = IriReference.FromDataSegments(baseIri, "a(1)", "b", "c");
-        
+
         // Assert
         newIri.Should().NotBeNull();
         newIri.ToString().Should().Be("https://example.com/%3C%2Fparam%3E/a%281%29/b/c");

--- a/src/UnitTests/TestIriReference.cs
+++ b/src/UnitTests/TestIriReference.cs
@@ -59,4 +59,18 @@ public class TestIriReference
         iriRef.Should().NotBeNull();
         iriRef.Should().Be(expectedIriReference);
     }
+    
+    [Fact]
+    public void Segments__Are__Escaped()
+    {
+        // Arrange
+        var baseIri = new IriReference("https://example.com/");
+        
+        // Act
+        var newIri = IriReference.FromDataSegments(baseIri, "a(1)", "b", "c");
+        
+        // Assert
+        newIri.Should().NotBeNull();
+        newIri.ToString().Should().Be("https://example.com/%3C%2Fparam%3E/a%281%29/b/c");
+    }
 }

--- a/src/UnitTests/TestIriReference.cs
+++ b/src/UnitTests/TestIriReference.cs
@@ -71,6 +71,6 @@ public class TestIriReference
 
         // Assert
         newIri.Should().NotBeNull();
-        newIri.ToString().Should().Be("https://example.com/%3C%2Fparam%3E/a%281%29/b/c");
+        newIri.ToString().Should().Be("https://example.com/a%281%29/b/c");
     }
 }

--- a/src/UnitTests/TestIriReference.cs
+++ b/src/UnitTests/TestIriReference.cs
@@ -60,11 +60,13 @@ public class TestIriReference
         iriRef.Should().Be(expectedIriReference);
     }
 
-    [Fact]
-    public void Segments__Are__Escaped()
+    [Theory]
+    [InlineData("https://example.com/")]
+    [InlineData("https://example.com")]
+    public void Segments__Are__Escaped(string baseIriString)
     {
         // Arrange
-        var baseIri = new IriReference("https://example.com/");
+        var baseIri = new IriReference(baseIriString);
 
         // Act
         var newIri = IriReference.FromDataSegments(baseIri, "a(1)", "b", "c");


### PR DESCRIPTION
Adds a method for creating an IRI given data-value segments that are escaped and then merged to a path. Also a simple unit test. 

Fixes [AB#393138](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/393138)
